### PR TITLE
Allow specification of a password in url

### DIFF
--- a/mpdlcd/mpdwrapper.py
+++ b/mpdlcd/mpdwrapper.py
@@ -30,7 +30,14 @@ class MPDClient(utils.AutoRetryCandidate):
         super(MPDClient, self).__init__(*args, **kwargs)
         self._client = mpd.MPDClient()
         self._connected = False
-        self.host = host
+        p=host.find('@')
+        if p>=0:
+            self.password = host[:p]
+            self.host = host[p+1:]
+            logger.debug(u'mpd url contained a password: %s',self.password)
+        else:
+            self.password = None
+            self.host = host
         self.port = port
 
     def _decode_text(self, text):
@@ -47,6 +54,10 @@ class MPDClient(utils.AutoRetryCandidate):
         if not self._connected:
             logger.info(u'Connecting to MPD server at %s:%s', self.host, self.port)
             self._client.connect(host=self.host, port=self.port)
+            if self.password:
+                # try to send the password, will throw an Exception if none is needed
+                logger.debug(u'sending password: %s',self.password)
+                self._client.password(self.password)
             self._connected = True
 
     @property


### PR DESCRIPTION
The mpd url now allows specification of a password in the form of a username.

in the config file this reads:

<pre>
# MPD server
mpd = secret@host:port
</pre>

or similiar using the commandline

<pre>
 # mpdlcd --mpd=secret@host:port
</pre>
