### PR TITLE
Support for different screen priorities

### DIFF
--- a/man/mpdlcd.1
+++ b/man/mpdlcd.1
@@ -185,6 +185,17 @@ Decides when the LCD's backlight should be enabled.
  'always' means "always on", 'never' "always off", 'play' is for "on while playing"
  and 'playpause' for "on while playing or paused".
 .
+.\" --priority-playing
+.TP
+.BI \-\^\-priority-playing " [foreground|idle|background]"
+Set the LCDproc screen priority while music is playing.
+.
+.
+.\" --priority-not-playing
+.TP
+.BI \-\^\-priority-not-playing " [foreground|idle|background]"
+Set the LCDproc screen priority while music is not playing.
+.
 .\" --pattern
 .TP
 .BI \-\^\-pattern " PATTERN"

--- a/mpdlcd.conf
+++ b/mpdlcd.conf
@@ -13,6 +13,10 @@ lcdproc_screen = MPD
 # - playpause: when playing or in pause
 backlight_on = play
 
+# Settings for changing the priority when backlight is switched on or off
+priority_backlight_on = foreground
+priority_backlight_off = background
+
 
 [patterns]
 

--- a/mpdlcd.conf
+++ b/mpdlcd.conf
@@ -13,9 +13,9 @@ lcdproc_screen = MPD
 # - playpause: when playing or in pause
 backlight_on = play
 
-# Settings for changing the priority when backlight is switched on or off
-priority_backlight_on = foreground
-priority_backlight_off = background
+# Settings for changing the screen priority when music is playing or not
+priority_playing = foreground
+priority_not_playing = background
 
 
 [patterns]

--- a/mpdlcd/cli.py
+++ b/mpdlcd/cli.py
@@ -33,6 +33,7 @@ DEFAULT_REFRESH = 0.5
 DEFAULT_LCD_SCREEN_NAME = 'MPD'
 DEFAULT_PATTERN = ''
 DEFAULT_BACKLIGHT_ON = enums.BACKLIGHT_ON_NEVER
+DEFAULT_PRIORITY = 'foreground'
 
 # Connection
 DEFAULT_MPD_PORT = 6600
@@ -56,6 +57,8 @@ BASE_CONFIG = {
         'lcdproc_screen': ('str', DEFAULT_LCD_SCREEN_NAME),
         'pattern': ('str', DEFAULT_PATTERN),
         'backlight_on': ('str', DEFAULT_BACKLIGHT_ON),
+        'priority_backlight_on': ('str', DEFAULT_PRIORITY),
+        'priority_backlight_off': ('str', DEFAULT_PRIORITY),
     },
     'connections': {
         'mpd': ('str', 'localhost:%s' % DEFAULT_MPD_PORT),
@@ -189,6 +192,8 @@ def run_forever(lcdproc='', mpd='', lcdproc_screen=DEFAULT_LCD_SCREEN_NAME,
         pattern='', patterns=[],
         refresh=DEFAULT_REFRESH,
         backlight_on=DEFAULT_BACKLIGHT_ON,
+        priority_backlight_on=DEFAULT_PRIORITY,
+        priority_backlight_off=DEFAULT_PRIORITY,
         retry_attempts=DEFAULT_RETRY_ATTEMPTS,
         retry_wait=DEFAULT_RETRY_WAIT,
         retry_backoff=DEFAULT_RETRY_BACKOFF):
@@ -300,6 +305,12 @@ def _make_parser():
             DEFAULT_BACKLIGHT_ON,
             choices=enums.BACKLIGHT_ON_CHOICES,
             metavar='BACKLIGHT_ON')
+    group.add_option('--priority-backlight-on', dest='priority-backlight_on',
+            help="Screen priority when backlight on (default: %s)" % DEFAULT_PRIORITY,
+            metavar='PRIORITY_BACKLIGHT_ON')
+    group.add_option('--priority-backlight-off', dest='priority-backlight_off',
+            help="Screen priority when backlight off (default: %s)" % DEFAULT_PRIORITY,
+            metavar='PRIORITY_BACKLIGHT_OFF')
 
     # End display options
     parser.add_option_group(group)
@@ -493,5 +504,6 @@ def main(argv):
     run_forever(**_extract_options(base_config, options,
         'lcdproc', 'mpd', 'lcdproc_charset', 'lcdproc_screen', 'lcdd_debug',
         'refresh', 'backlight_on',
+        'priority_backlight_on', 'priority_backlight_off',
         'pattern', 'patterns',
         'retry_attempts', 'retry_backoff', 'retry_wait'))

--- a/mpdlcd/cli.py
+++ b/mpdlcd/cli.py
@@ -57,8 +57,8 @@ BASE_CONFIG = {
         'lcdproc_screen': ('str', DEFAULT_LCD_SCREEN_NAME),
         'pattern': ('str', DEFAULT_PATTERN),
         'backlight_on': ('str', DEFAULT_BACKLIGHT_ON),
-        'priority_backlight_on': ('str', DEFAULT_PRIORITY),
-        'priority_backlight_off': ('str', DEFAULT_PRIORITY),
+        'priority_playing': ('str', DEFAULT_PRIORITY),
+        'priority_not_playing': ('str', DEFAULT_PRIORITY),
     },
     'connections': {
         'mpd': ('str', 'localhost:%s' % DEFAULT_MPD_PORT),
@@ -192,8 +192,8 @@ def run_forever(lcdproc='', mpd='', lcdproc_screen=DEFAULT_LCD_SCREEN_NAME,
         pattern='', patterns=[],
         refresh=DEFAULT_REFRESH,
         backlight_on=DEFAULT_BACKLIGHT_ON,
-        priority_backlight_on=DEFAULT_PRIORITY,
-        priority_backlight_off=DEFAULT_PRIORITY,
+        priority_playing=DEFAULT_PRIORITY,
+        priority_not_playing=DEFAULT_PRIORITY,
         retry_attempts=DEFAULT_RETRY_ATTEMPTS,
         retry_wait=DEFAULT_RETRY_WAIT,
         retry_backoff=DEFAULT_RETRY_BACKOFF):
@@ -241,8 +241,8 @@ def run_forever(lcdproc='', mpd='', lcdproc_screen=DEFAULT_LCD_SCREEN_NAME,
         refresh_rate=refresh,
         retry_config=retry_config,
         backlight_on=backlight_on,
-        priority_backlight_on=priority_backlight_on,
-        priority_backlight_off=priority_backlight_off,
+        priority_playing=priority_playing,
+        priority_not_playing=priority_not_playing,
     )
 
     # Fill pattern
@@ -307,12 +307,12 @@ def _make_parser():
             DEFAULT_BACKLIGHT_ON,
             choices=enums.BACKLIGHT_ON_CHOICES,
             metavar='BACKLIGHT_ON')
-    group.add_option('--priority-backlight-on', dest='priority-backlight_on',
-            help="Screen priority when backlight on (default: %s)" % DEFAULT_PRIORITY,
-            metavar='PRIORITY_BACKLIGHT_ON')
-    group.add_option('--priority-backlight-off', dest='priority-backlight_off',
-            help="Screen priority when backlight off (default: %s)" % DEFAULT_PRIORITY,
-            metavar='PRIORITY_BACKLIGHT_OFF')
+    group.add_option('--priority-playing', dest='priority_playing',
+            help="Screen priority when music is playing (default: %s)" % DEFAULT_PRIORITY,
+            metavar='PRIORITY_PLAYING')
+    group.add_option('--priority-not-playing', dest='priority_not_playing',
+            help="Screen priority when music is not playing (default: %s)" % DEFAULT_PRIORITY,
+            metavar='PRIORITY_NOT_PLAYING')
 
     # End display options
     parser.add_option_group(group)
@@ -506,6 +506,6 @@ def main(argv):
     run_forever(**_extract_options(base_config, options,
         'lcdproc', 'mpd', 'lcdproc_charset', 'lcdproc_screen', 'lcdd_debug',
         'refresh', 'backlight_on',
-        'priority_backlight_on', 'priority_backlight_off',
+        'priority_playing', 'priority_not_playing',
         'pattern', 'patterns',
         'retry_attempts', 'retry_backoff', 'retry_wait'))

--- a/mpdlcd/cli.py
+++ b/mpdlcd/cli.py
@@ -241,6 +241,8 @@ def run_forever(lcdproc='', mpd='', lcdproc_screen=DEFAULT_LCD_SCREEN_NAME,
         refresh_rate=refresh,
         retry_config=retry_config,
         backlight_on=backlight_on,
+        priority_backlight_on=priority_backlight_on,
+        priority_backlight_off=priority_backlight_off,
     )
 
     # Fill pattern

--- a/mpdlcd/display_fields.py
+++ b/mpdlcd/display_fields.py
@@ -190,6 +190,27 @@ class BacklightPseudoField(Field):
         logger.debug(u"Setting backlight to %s", backlight)
         self._screen.set_backlight(backlight)
 
+class PriorityPseudoField(Field):
+    base_name = 'priority'
+    target_hooks = ['state']
+
+    def __init__(self, priority_playing, priority_not_playing, **kwargs):
+        self.priority_playing=priority_playing
+        self.priority_not_playing=priority_not_playing
+        self._screen = None
+        super(PriorityPseudoField, self).__init__(width=0, **kwargs)
+
+    def add_to_screen(self, screen, left, top):
+        self._screen = screen
+
+    def state_changed(self, widget, new_state):
+        if new_state == MPD_PLAY:
+            priority = self.priority_playing
+        else:
+            priority = self.priority_not_playing
+        logger.debug(u"Setting priority to %s", priority)
+        self._screen.set_priority(priority)
+
 
 class BaseTimeField(Field):
     target_hooks = ['state', 'elapsed_and_total']

--- a/mpdlcd/lcdrunner.py
+++ b/mpdlcd/lcdrunner.py
@@ -46,14 +46,14 @@ class LcdProcServer(server.Server):
 
 
 class MpdRunner(utils.AutoRetryCandidate):
-    def __init__(self, client, lcd, lcdproc_screen, refresh_rate, backlight_on, priority_backlight_on, priority_backlight_off, *args, **kwargs):
+    def __init__(self, client, lcd, lcdproc_screen, refresh_rate, backlight_on, priority_playing, priority_not_playing, *args, **kwargs):
         super(MpdRunner, self).__init__(logger=logger, *args, **kwargs)
 
         self.lcd = lcd
         self.lcdproc_screen = lcdproc_screen
         self.backlight_on = backlight_on
-        self.priority_backlight_on = priority_backlight_on
-        self.priority_backlight_off = priority_backlight_off
+        self.priority_playing = priority_playing
+        self.priority_not_playing = priority_not_playing
         self.refresh_rate = refresh_rate
 
         # Make sure we can connect - no need to go further otherwise.
@@ -72,7 +72,7 @@ class MpdRunner(utils.AutoRetryCandidate):
         logger.debug(u'Adding lcdproc screen %s', screen_name)
         screen = self.lcd.add_screen(screen_name)
         screen.set_heartbeat('off')
-        screen.set_priority(self.priority_backlight_on)
+        screen.set_priority(self.priority_playing)
 
         width = self.lcd.server_info['screen_width']
         height = self.lcd.server_info['screen_height']
@@ -93,7 +93,7 @@ class MpdRunner(utils.AutoRetryCandidate):
             )
 
         fields.append(
-            display_fields.PriorityPseudoField(ref='0', priority_playing=self.priority_backlight_on, priority_not_playing=self.priority_backlight_off)
+            display_fields.PriorityPseudoField(ref='0', priority_playing=self.priority_playing, priority_not_playing=self.priority_not_playing)
         )
 
         self.pattern.add_pseudo_fields(fields, self.screen)

--- a/mpdlcd/lcdrunner.py
+++ b/mpdlcd/lcdrunner.py
@@ -46,12 +46,14 @@ class LcdProcServer(server.Server):
 
 
 class MpdRunner(utils.AutoRetryCandidate):
-    def __init__(self, client, lcd, lcdproc_screen, refresh_rate, backlight_on, *args, **kwargs):
+    def __init__(self, client, lcd, lcdproc_screen, refresh_rate, backlight_on, priority_backlight_on, priority_backlight_off, *args, **kwargs):
         super(MpdRunner, self).__init__(logger=logger, *args, **kwargs)
 
         self.lcd = lcd
         self.lcdproc_screen = lcdproc_screen
         self.backlight_on = backlight_on
+        self.priority_backlight_on = priority_backlight_on
+        self.priority_backlight_off = priority_backlight_off
         self.refresh_rate = refresh_rate
 
         # Make sure we can connect - no need to go further otherwise.
@@ -70,7 +72,7 @@ class MpdRunner(utils.AutoRetryCandidate):
         logger.debug(u'Adding lcdproc screen %s', screen_name)
         screen = self.lcd.add_screen(screen_name)
         screen.set_heartbeat('off')
-        screen.set_priority(64)
+        screen.set_priority(self.priority_backlight_on)
 
         width = self.lcd.server_info['screen_width']
         height = self.lcd.server_info['screen_height']
@@ -89,6 +91,10 @@ class MpdRunner(utils.AutoRetryCandidate):
             fields.append(
                 display_fields.BacklightPseudoField(ref='0', backlight_rule=self.backlight_on)
             )
+
+        fields.append(
+            display_fields.PriorityPseudoField(ref='0', priority_playing=self.priority_backlight_on, priority_not_playing=self.priority_backlight_off)
+        )
 
         self.pattern.add_pseudo_fields(fields, self.screen)
 


### PR DESCRIPTION
I wanted my HTPC to display information about the song while MPD is playing music and to let the Kodi LCDproc-plugin handle the display while music is not playing. With this modification the LCDproc screen priorities solved the problem nicely.
